### PR TITLE
return correct filename

### DIFF
--- a/lib/rbscreenshot.rb
+++ b/lib/rbscreenshot.rb
@@ -3,18 +3,12 @@ require 'capybara/poltergeist'
 
 class RbScreenShot
   class << self
-    def take(url)
-      session(url).save_screenshot(filename, full: true)
-      filename
+    def take(url, full: true)
+      session(url).save_screenshot("#{Time.now.to_i.to_s}.png", full: full)
     end
 
     def take_part(url)
-      session(url).save_screenshot(filename)
-      filename
-    end
-
-    def filename
-      "#{Time.now.to_i.to_s}.png"
+      take(url, full: false)
     end
 
     def session(url)


### PR DESCRIPTION
Currently, `#take` or `#take_part` returns incorrect filename :cry:
Anyway `#save_screenshot` returns the saved filename, so we can just use that.
I will really appreciate if you merge this PR :smile:

see also: http://www.rubydoc.info/github/jnicklas/capybara/Capybara%2FSession%3Asave_screenshot
